### PR TITLE
Treat boolean arguments as booleans.

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -6,7 +6,7 @@ path = require 'path'
 
 _ = require 'lodash'
 colors = require 'colors'
-argv = require('minimist')(process.argv.slice(2))
+argv = require('minimist')(process.argv.slice(2), { boolean : ['i','a','c','v','x'] })
 
 # Package info is used by version reporter.
 info = require '../package.json'


### PR DESCRIPTION
When specifying boolean arguments (such as 'i' or 'a'), the current configuration expects the next string to be a value, which in many cases eats the input directory argument.

Example: 
assetpress -a inputDir 
results in an error saying that no source dir was specified. That's because we need to treat -a as a boolean argument.
